### PR TITLE
Ensure deleting-compaction-strategy removes row tombstones

### DIFF
--- a/deleting-compaction-strategy/src/main/java/com/protectwise/cassandra/db/columniterator/FilteringOnDiskAtomIterator.java
+++ b/deleting-compaction-strategy/src/main/java/com/protectwise/cassandra/db/columniterator/FilteringOnDiskAtomIterator.java
@@ -121,7 +121,7 @@ public class FilteringOnDiskAtomIterator implements OnDiskAtomIterator {
     public ColumnFamily getColumnFamily() {
         ColumnFamily underlyingColumnFamily = underlying.getColumnFamily();
         DeletionTime topLevelDeletion = underlyingColumnFamily.deletionInfo().getTopLevelDeletion();
-        if (filter.shouldKeepTopLevelDeletion(underlying, topLevelDeletion))
+        if (topLevelDeletion.isLive() || filter.shouldKeepTopLevelDeletion(underlying, topLevelDeletion))
         {
             return underlyingColumnFamily;
         }

--- a/deleting-compaction-strategy/src/main/java/com/protectwise/cassandra/db/columniterator/FilteringOnDiskAtomIterator.java
+++ b/deleting-compaction-strategy/src/main/java/com/protectwise/cassandra/db/columniterator/FilteringOnDiskAtomIterator.java
@@ -117,7 +117,16 @@ public class FilteringOnDiskAtomIterator implements OnDiskAtomIterator {
      */
     @Override
     public ColumnFamily getColumnFamily() {
-        return underlying.getColumnFamily();
+        ColumnFamily underlyingColumnFamily = underlying.getColumnFamily();
+        DeletionTime topLevelDeletion = underlyingColumnFamily.deletionInfo().getTopLevelDeletion();
+        if (filter.shouldKeepTopLevelDeletion(underlying, topLevelDeletion))
+        {
+          return underlyingColumnFamily;
+        }
+        else
+        {
+          return ArrayBackedSortedColumns.factory.create(underlyingColumnFamily.metadata());
+        }
     }
 
     /**

--- a/deleting-compaction-strategy/src/main/java/com/protectwise/cassandra/db/columniterator/FilteringOnDiskAtomIterator.java
+++ b/deleting-compaction-strategy/src/main/java/com/protectwise/cassandra/db/columniterator/FilteringOnDiskAtomIterator.java
@@ -45,6 +45,7 @@ public class FilteringOnDiskAtomIterator implements OnDiskAtomIterator {
     protected final ColumnFamilyStore cfs;
     protected final List<Cell> indexedColumnsInRow;
     protected final boolean dryRun;
+    protected final IDeletedRecordsSink backupSink;
 
     public long kept = 0;
     public long filtered = 0;
@@ -60,6 +61,7 @@ public class FilteringOnDiskAtomIterator implements OnDiskAtomIterator {
         this.filter = filter;
         this.cfs = cfs;
         this.dryRun = dryRun;
+        this.backupSink = backupSink;
 
         final boolean hasIndexes = cfs.indexManager.hasIndexes();
         if (hasIndexes) this.indexedColumnsInRow = new ArrayList<Cell>();
@@ -125,6 +127,10 @@ public class FilteringOnDiskAtomIterator implements OnDiskAtomIterator {
         }
         else
         {
+            if (backupSink != null)
+            {
+                backupSink.accept(underlying.getKey(), topLevelDeletion);
+            }
             return ArrayBackedSortedColumns.factory.create(underlyingColumnFamily.metadata());
         }
     }

--- a/deleting-compaction-strategy/src/main/java/com/protectwise/cassandra/db/columniterator/FilteringOnDiskAtomIterator.java
+++ b/deleting-compaction-strategy/src/main/java/com/protectwise/cassandra/db/columniterator/FilteringOnDiskAtomIterator.java
@@ -121,11 +121,11 @@ public class FilteringOnDiskAtomIterator implements OnDiskAtomIterator {
         DeletionTime topLevelDeletion = underlyingColumnFamily.deletionInfo().getTopLevelDeletion();
         if (filter.shouldKeepTopLevelDeletion(underlying, topLevelDeletion))
         {
-          return underlyingColumnFamily;
+            return underlyingColumnFamily;
         }
         else
         {
-          return ArrayBackedSortedColumns.factory.create(underlyingColumnFamily.metadata());
+            return ArrayBackedSortedColumns.factory.create(underlyingColumnFamily.metadata());
         }
     }
 

--- a/deleting-compaction-strategy/src/main/java/com/protectwise/cassandra/db/columniterator/IOnDiskAtomFilter.java
+++ b/deleting-compaction-strategy/src/main/java/com/protectwise/cassandra/db/columniterator/IOnDiskAtomFilter.java
@@ -15,10 +15,12 @@
  */
 package com.protectwise.cassandra.db.columniterator;
 
+import org.apache.cassandra.db.DeletionTime;
 import org.apache.cassandra.db.OnDiskAtom;
 import org.apache.cassandra.db.columniterator.OnDiskAtomIterator;
 import org.apache.cassandra.db.composites.Composite;
 
 public interface IOnDiskAtomFilter {
     public boolean shouldKeepAtom(OnDiskAtomIterator partition, OnDiskAtom atom);
+    public boolean shouldKeepTopLevelDeletion(OnDiskAtomIterator partition, DeletionTime deletionTime);
 }

--- a/deleting-compaction-strategy/src/main/java/com/protectwise/cassandra/db/compaction/AbstractSimpleDeletingConvictor.java
+++ b/deleting-compaction-strategy/src/main/java/com/protectwise/cassandra/db/compaction/AbstractSimpleDeletingConvictor.java
@@ -21,6 +21,7 @@ import org.apache.cassandra.config.ColumnDefinition;
 import org.apache.cassandra.db.Cell;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.DeletionTime;
 import org.apache.cassandra.db.OnDiskAtom;
 import org.apache.cassandra.db.columniterator.OnDiskAtomIterator;
 import org.apache.cassandra.db.composites.Composite;
@@ -114,6 +115,12 @@ public abstract class AbstractSimpleDeletingConvictor implements ISSTableScanner
 
 	@Override
 	public boolean shouldKeepAtom(OnDiskAtomIterator partition, OnDiskAtom atom)
+	{
+		return true;
+	}
+
+	@Override
+	public boolean shouldKeepTopLevelDeletion(OnDiskAtomIterator partition, DeletionTime deletionTime)
 	{
 		return true;
 	}

--- a/deleting-compaction-strategy/src/main/java/com/protectwise/cassandra/db/compaction/BackupSinkForDeletingCompaction.java
+++ b/deleting-compaction-strategy/src/main/java/com/protectwise/cassandra/db/compaction/BackupSinkForDeletingCompaction.java
@@ -70,11 +70,25 @@ public class BackupSinkForDeletingCompaction implements IDeletedRecordsSink
 	{
 		flush();
 		currentKey = partition.getKey();
+		accept(partition.getKey(), partition.getColumnFamily().deletionInfo().getTopLevelDeletion());
 		// Write through the entire partition.
 		while (partition.hasNext())
 		{
 			accept(partition.getKey(), partition.next());
 		}
+	}
+
+	@Override
+	public void accept(DecoratedKey key, DeletionTime topLevelDeletion)
+	{
+		if (currentKey != key)
+		{
+			flush();
+			currentKey = key;
+		}
+
+		columnFamily.delete(topLevelDeletion);
+		isEmpty = false;
 	}
 
 	@Override

--- a/deleting-compaction-strategy/src/main/java/com/protectwise/cassandra/db/compaction/IDeletedRecordsSink.java
+++ b/deleting-compaction-strategy/src/main/java/com/protectwise/cassandra/db/compaction/IDeletedRecordsSink.java
@@ -16,6 +16,7 @@
 package com.protectwise.cassandra.db.compaction;
 
 import org.apache.cassandra.db.DecoratedKey;
+import org.apache.cassandra.db.DeletionTime;
 import org.apache.cassandra.db.OnDiskAtom;
 import org.apache.cassandra.db.columniterator.OnDiskAtomIterator;
 import org.slf4j.Logger;
@@ -30,6 +31,13 @@ public interface IDeletedRecordsSink extends AutoCloseable
 	 * @param partition
 	 */
 	void accept(OnDiskAtomIterator partition);
+
+	/**
+	 * Accept an partition deletion time
+	 * @param key
+	 * @param topLevelDeletion
+	 */
+	void accept(DecoratedKey key, DeletionTime topLevelDeletion);
 
 	/**
 	 * Accept just some cells of a partition

--- a/deleting-compaction-strategy/src/main/java/com/protectwise/cassandra/io/sstable/FilteringSSTableScanner.java
+++ b/deleting-compaction-strategy/src/main/java/com/protectwise/cassandra/io/sstable/FilteringSSTableScanner.java
@@ -24,6 +24,7 @@ import com.protectwise.cassandra.db.compaction.IDeletedRecordsSink;
 import org.apache.cassandra.db.Cell;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.DataRange;
+import org.apache.cassandra.db.DeletionTime;
 import org.apache.cassandra.db.OnDiskAtom;
 import org.apache.cassandra.db.columniterator.OnDiskAtomIterator;
 import org.apache.cassandra.dht.Range;
@@ -154,6 +155,12 @@ public class FilteringSSTableScanner implements ISSTableScanner
 							indexedColumnsInRow.add((Cell) column);
 						}
 						// Keep all records so they make it into the backup sink.
+						return true;
+					}
+
+					@Override
+					public boolean shouldKeepTopLevelDeletion(OnDiskAtomIterator partition, DeletionTime deletionTime)
+					{
 						return true;
 					}
 				}, cfs, false, null));

--- a/deleting-compaction-strategy/src/main/java/com/protectwise/cassandra/retrospect/deletion/RuleBasedLateTTLConvictor.java
+++ b/deleting-compaction-strategy/src/main/java/com/protectwise/cassandra/retrospect/deletion/RuleBasedLateTTLConvictor.java
@@ -659,7 +659,7 @@ public class RuleBasedLateTTLConvictor extends AbstractClusterDeletingConvictor
 	{
 		final long atomTimestampInMillis = deletionTime.markedForDeleteAt / 1000;
 		final long recordAgeInSeconds = (this.fixedTtlBaseTime - atomTimestampInMillis) / 1000;
-		final boolean shouldKeep = (effectiveTTL == null) || (recordAgeInSeconds <= effectiveTTL);
+		final boolean shouldKeep = (effectiveTTL == null) || (effectiveTTL < 0) || (recordAgeInSeconds <= effectiveTTL);
 		if (logger.isTraceEnabled())
 		{
 			logger.trace("TopLevelDeletion age {}, effective TTL of {}, {} {}.", recordAgeInSeconds, effectiveTTL, (shouldKeep ? "keeping" : "deleting"), PrintHelper.print(partition, cfs));


### PR DESCRIPTION
When a full row is deleted, Cassandra creates a row tombstone, also known as a top-level deletion, which is different from both a range tombstone and a regular tombstone. This tombstone is handled specially inside Cassandra, and never yielded by any `OnDiskAtomIterator`. Instead, it is tucked away inside the metadata inside the column family accessor of the `OnDiskAtomIterator`.

This means that a row tombstone will never be deleted by the deleting compaction strategy, unless the whole row is deleted. Concretely, this means that when using the `RuleBasedLateTTLConvictor` on a table where full rows have been deleted, the row tombstones will not be deleted.

This introduces a new method to the `IOnDiskAtomFilter` to allow deletion of row tombstones and uses that in the `RuleBasedLateTTLConvictor` to signal that tombstone within the partition TTL should be removed.